### PR TITLE
Changed "delete-form" from "id" to "class"

### DIFF
--- a/views/reviews/index.ejs
+++ b/views/reviews/index.ejs
@@ -40,7 +40,7 @@
                             <% if(currentUser && review.author.id.equals(currentUser._id)){ %>
                             <a class="btn btn-xs btn-warning"
                                href="/campgrounds/<%=campground._id %>/reviews/<%=review._id %>/edit">Edit</a>
-                            <form id="delete-form" action="/campgrounds/<%=campground._id %>/reviews/<%=review._id %>?_method=DELETE" method="POST">
+                            <form class="delete-form" action="/campgrounds/<%=campground._id %>/reviews/<%=review._id %>?_method=DELETE" method="POST">
                                 <input type="submit" class="btn btn-xs btn-danger" value="Delete">
                             </form>
                             <% } %>


### PR DESCRIPTION
"delete-form" is also used (as a class) in "show.ejs", which also uses the "main.css" file (have likewise proposed a change to the "delete-form" selector - from "#" to "." - in "main.css").